### PR TITLE
bugfix: add "charset; utf-8" check to json response object "content-ype" header.

### DIFF
--- a/lib/resty/requests/response.lua
+++ b/lib/resty/requests/response.lua
@@ -301,8 +301,10 @@ local function json(r)
     end
 
     local content_type = r.headers["Content-Type"]
-    if content_type ~= "application/json" then
-        return nil, "not json"
+    if content_type ~= "application/json"
+        and content_type ~= "application/json; charset=utf-8"
+        and content_type ~= "application/json; charset=UTF-8" then
+            return nil, "not json"
     end
 
     return cjson.decode(data)


### PR DESCRIPTION
Even though UTF-8 is the default JSON encoding, some APIs return the content-type header as `"Content-type: application/json; charset=utf-8"` (or `"Content-type: application/json; charset=UTF-8"`).

This bugfix includes checking for "charset" in the content-type header because otherwise the JSON function returns `nil,"not json"` on valid JSON response.