### PR TITLE
refactor: refactored the request/response headers table logic.

### DIFF
--- a/lib/resty/requests/adapter.lua
+++ b/lib/resty/requests/adapter.lua
@@ -106,6 +106,7 @@ local function parse_headers(self)
         end
 
         if name and value then
+            -- FIXME transform underscore to hyphen
             name = lower(name)
 
             local ovalue = headers[name]

--- a/lib/resty/requests/request.lua
+++ b/lib/resty/requests/request.lua
@@ -71,31 +71,31 @@ local function prepare(url_parts, session, config)
 
     if json then
         content = cjson.encode(json)
-        headers["Content-Length"] = #content
-        headers["Content-Type"] = "application/json"
+        headers["content-length"] = #content
+        headers["content-type"] = "application/json"
     else
         content = body
         if is_func(body) then
             -- users may know their request body size
-            if not headers["Content-Length"] then
-                headers["Transfer-Encoding"] = "chunked"
+            if not headers["content-length"] then
+                headers["transfer-encoding"] = "chunked"
             end
 
-            if not headers["Content-Type"] and config.use_default_type then
-                headers["Content-Type"] = "application/octet-stream"
+            if not headers["content-type"] and config.use_default_type then
+                headers["content-type"] = "application/octet-stream"
             end
 
         elseif is_str(body) then
-            headers["Content-Length"] = #body
-            headers["Transfer-Encoding"] = nil
+            headers["content-length"] = #body
+            headers["transfer-encoding"] = nil
 
-            if not headers["Content-Type"] and config.use_default_type then
-                headers["Content-Type"] = "text/plain"
+            if not headers["content-type"] and config.use_default_type then
+                headers["content-type"] = "text/plain"
             end
 
         elseif is_tab(body) then
-            if not headers["Content-Type"] and config.use_default_type then
-                headers["Content-Type"] = "application/x-www-form-urlencoded"
+            if not headers["content-type"] and config.use_default_type then
+                headers["content-type"] = "application/x-www-form-urlencoded"
             end
 
             local param = new_tab(4, 0)
@@ -104,24 +104,24 @@ local function prepare(url_parts, session, config)
             end
 
             content = concat(param, "&")
-            headers["Content-Length"] = #content
-            headers["Transfer-Encoding"] = nil
+            headers["content-length"] = #content
+            headers["transfer-encoding"] = nil
         end
     end
 
-    if not headers["Host"] then
-        headers["Host"] = url_parts.host
+    if not headers["host"] then
+        headers["host"] = url_parts.host
     end
 
-    if headers["Transfer-Encoding"] then
-        headers["Content-Length"] = nil
+    if headers["transfer-encoding"] then
+        headers["content-length"] = nil
     end
 
-    headers["Connection"] = "keep-alive"
+    headers["connection"] = "keep-alive"
 
     local auth = session.auth
     if auth then
-        headers["Authorization"] = auth
+        headers["authorization"] = auth
     end
 
     local cookie = session.cookie
@@ -131,7 +131,7 @@ local function prepare(url_parts, session, config)
             insert(plain, ("%s=%s"):format(k, v))
         end
 
-        headers["Cookie"] = concat(plain, "; ")
+        headers["cookie"] = concat(plain, "; ")
     end
 
     return content
@@ -146,7 +146,7 @@ local function new(method, url, session, config)
 
     local body = prepare(url_parts, session, config)
 
-    local expect = session.headers["Expect"] == "100-continue"
+    local expect = session.headers["expect"] == "100-continue"
 
     local r = {
         method = method,

--- a/lib/resty/requests/response.lua
+++ b/lib/resty/requests/response.lua
@@ -205,7 +205,7 @@ local function new(opts)
     end
 
     if r._http_ver ~= HTTP20 then
-        local chunk = r.headers["Transfer-Encoding"]
+        local chunk = r.headers["transfer-encoding"]
         if chunk and find(chunk, "chunked", nil, true) then
             r._chunk = {
                 size = 0, -- current chunked header size
@@ -214,14 +214,14 @@ local function new(opts)
                 reader = r._adapter:reader("\r\n"),
             }
         else
-            r._rest = tonumber(r.headers["Content-Length"])
+            r._rest = tonumber(r.headers["content-length"])
             if r._rest == 0 or no_body(r) then
                 r._read_eof = true
             end
         end
     end
 
-    local connection = r.headers["Connection"]
+    local connection = r.headers["connection"]
     if connection == "keep-alive" or r._http_ver == HTTP20 then
         r._keepalive = true
     end
@@ -301,7 +301,7 @@ local function json(r)
         return nil, err
     end
 
-    local content_type = r.headers["Content-Type"]
+    local content_type = r.headers["content-type"]
     if not content_type then
         return nil, "not json"
     end

--- a/lib/resty/requests/session.lua
+++ b/lib/resty/requests/session.lua
@@ -7,7 +7,6 @@ local adapter = require "resty.requests.adapter"
 local setmetatable = setmetatable
 local format = string.format
 local pairs = pairs
-local new_tab = util.new_tab
 local ngx_now = ngx.now
 
 local _M = { _VERSION = "0.2" }
@@ -17,7 +16,7 @@ local BUILTIN_HEADERS = util.BUILTIN_HEADERS
 local send_request
 
 local function new()
-    local headers = new_tab(0, 8)
+    local headers = util.dict(nil, 0, 8)
 
     for k, v in pairs(BUILTIN_HEADERS) do
         headers[k] = v

--- a/t/00-sanity.t
+++ b/t/00-sanity.t
@@ -182,10 +182,10 @@ GET /t
 
 --- response_body eval
 qq{GET /t1?foo=bar&c= HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Connection: keep-alive\r
-Host: 127.0.0.1\r
+host: 127.0.0.1\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
 \r
 };
 
@@ -235,11 +235,11 @@ GET /t
 
 --- response_body eval
 qq{GET /t1 HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Connection: keep-alive\r
-Cache-Control: max-age=0\r
-Host: 127.0.0.1\r
+cache-control: max-age=0\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
+host: 127.0.0.1\r
 \r
 }
 
@@ -280,12 +280,12 @@ GET /t1
 --- status_code: 200
 --- response_body eval
 qq{GET /t3?usebody=true&af=b HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Content-Type: text/plain\r
-Connection: keep-alive\r
-Content-Length: 18\r
-Host: 127.0.0.1\r
+host: 127.0.0.1\r
+content-length: 18\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
+content-type: text/plain\r
 \r
 你好吗？Hello?}
 
@@ -329,12 +329,12 @@ GET /t1
 
 --- response_body eval
 qq{GET /t3 HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Connection: keep-alive\r
-Content-Type: application/octet-stream\r
-Host: 127.0.0.1\r
-Transfer-Encoding: chunked\r
+host: 127.0.0.1\r
+content-type: application/octet-stream\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
+transfer-encoding: chunked\r
 \r
 hellohellohellohello}
 
@@ -524,10 +524,10 @@ GET /t1
 
 --- response_body eval
 qq{GET /t1?test=event_hook HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Connection: keep-alive\r
-Host: 127.0.0.1\r
+host: 127.0.0.1\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
 \r
 };
 
@@ -1093,11 +1093,11 @@ GET /t
 
 --- response_body eval
 qq{GET /t1 HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Connection: keep-alive\r
-Content-Length: 3\r
-Host: 127.0.0.1\r
+host: 127.0.0.1\r
+content-length: 3\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
 \r
 };
 --- no_error_log

--- a/t/02-shortpath.t
+++ b/t/02-shortpath.t
@@ -77,11 +77,11 @@ GET /t
 
 --- response_body eval
 qq{GET /t1 HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Cookie: name3=value3; name1=value1; name2=value2\r
-Connection: keep-alive\r
-Host: 127.0.0.1\r
+host: 127.0.0.1\r
+cookie: name3=value3; name1=value1; name2=value2\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
 \r
 };
 
@@ -125,11 +125,11 @@ GET /t
 
 --- response_body eval
 qq{GET /t1 HTTP/1.1\r
-User-Agent: resty-requests\r
-Accept: */*\r
-Authorization: Basic YWxleDoxMjM0NTY=\r
-Connection: keep-alive\r
-Host: 127.0.0.1\r
+host: 127.0.0.1\r
+authorization: Basic YWxleDoxMjM0NTY=\r
+user-agent: resty-requests\r
+accept: */*\r
+connection: keep-alive\r
 \r
 };
 


### PR DESCRIPTION
Previously, there is a bug in `session.headers`, we didn't assign the
`__index` metamethod to this table, which results in that all non-normalized
headers cannot be indexed.

This commit refactored this part of logic, all headers will be saved
with the lowercase and hyphen form. Also, session.headers will have the
`__index` metamethod (created by `util.dict()`).

In addition, now we use the lowercase and hyphen form to do the necessary header indexing jobs, this change can reduce some metamethod calling and it's good for the performance.

Unfortunately there are many test cases need to be modified...